### PR TITLE
User-friendly install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 ## Install
 
 ```fish
-$ git clone git://github.com/evanlucas/fish-kubectl-completions
 $ mkdir -p ~/.config/fish/completions
-$ cd fish-kubectl-completions
-$ ln -s (pwd)/kubectl.fish ~/.config/fish/completions/
+$ cd ~/.config/fish
+$ git clone https://github.com/evanlucas/fish-kubectl-completions
+$ ln -s ../fish-kubectl-completions/kubectl.fish completions/
 ```
 
 ## Author


### PR DESCRIPTION
The current install guide doesn't explain in which directory to put the cloned project. This PR makes it easier by suggesting a reasonable default. Also, it replaces git:// with https:// for ordinary folks without GitHub a/c.