### PR TITLE
Add Pod completion for port-forward

### DIFF
--- a/kubectl.fish
+++ b/kubectl.fish
@@ -362,7 +362,6 @@ complete -c kubectl -f -n '__fish_kubectl_needs_command' -a drain -d "Drain node
 complete -c kubectl -f -n '__fish_kubectl_needs_command' -a uncordon -d "Mark node as schedulable"
 complete -c kubectl -f -n '__fish_kubectl_needs_command' -a attach -d "Attach to a running container."
 complete -c kubectl -f -n '__fish_kubectl_needs_command' -a exec -d "Execute a command in a container."
-complete -c kubectl -f -n '__fish_kubectl_needs_command' -a port-forward -d "Forward one or more local ports to a pod."
 complete -c kubectl -f -n '__fish_kubectl_needs_command' -a proxy -d "Run a proxy to the Kubernetes API server"
 complete -c kubectl -f -n '__fish_kubectl_needs_command' -a run -d "Run a particular image on the cluster."
 complete -c kubectl -f -n '__fish_kubectl_needs_command' -a expose -d "Take a replication controller, service, deployment or pod and expose it as a new Kubernetes Service"
@@ -390,6 +389,10 @@ end
 # exec
 complete -c kubectl -f -n '__fish_kubectl_needs_command' -a exec -d 'Execute a command in a container.'
 complete -c kubectl -A -f -n '__fish_seen_subcommand_from exec' -a '(__fish_print_resource pods)' -d "Pod"
+
+# port-forward
+complete -c kubectl -f -n '__fish_kubectl_needs_command' -a port-forward -d "Forward one or more local ports to a pod."
+complete -c kubectl -A -f -n '__fish_seen_subcommand_from port-forward' -a '(__fish_print_resource pods)' -d "Pod"
 
 # version
 complete -c kubectl -f -n '__fish_kubectl_needs_command' -a version -d 'Print the client and server version information for the current context'


### PR DESCRIPTION
This adds Pod resource completion for the port-forward command, copied from exec.

I've never done a fish completion before and basically only copied the exec command specification, so this may not be correct, but does work for me. Sorry if I messed something up!