### PR TITLE
Add context support

### DIFF
--- a/kubectl.fish
+++ b/kubectl.fish
@@ -252,6 +252,25 @@ function __fish_kubectl_get_ns_flags
   return 1
 end
 
+function __fish_kubectl_get_context -d 'Gets the context for the current command'
+  set -l cmd (commandline -opc)
+  if [ (count $cmd) -eq 0 ]
+    echo ""
+    return 0
+  else
+    set -l foundContext 0
+    for c in $cmd
+      test $foundContext -eq 1
+      and echo "$c"
+      and return 0
+      if contains -- $c "--context"
+        set foundContext 1
+      end
+    end
+    return 1
+  end
+end
+
 function __fish_kubectl_print_resource_types
   for r in $__fish_kubectl_resources
     echo $r

--- a/kubectl.fish
+++ b/kubectl.fish
@@ -274,7 +274,11 @@ function __fish_kubectl_get_context_flags
     and echo $out
     and return 0
 
-    if contains -- $c "--context"
+    if string match -q -r -- "--context=" $c
+      set -l out (string split -- "=" $c | string join " ")
+      and echo $out
+      and return 0
+    else if contains -- $c "--context"
       set foundContext 1
     end
   end


### PR DESCRIPTION
We have over 10 clusters in our kube config files. Instead of switching the default context each time, we just use the --context switch to choose the cluster to work on.