### PR TITLE
update hashes to be compatible for go>=1.11.4

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -14,7 +14,7 @@ github.com/docker/distribution v2.6.0+incompatible h1:8hxvSzNSatS/Ik5y595JXjKnUj
 github.com/docker/distribution v2.6.0+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.0+incompatible h1:neUDAlf3wX6Ml4HdqTrbcOHXtfRN0TFIwt6YFL7N9RU=
 github.com/docker/distribution v2.7.0+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v0.7.3-0.20181229214054-f76d6a078d88 h1:guxdGfHIedsLlzNEEtw6weHoSr8QUJWR5n6bgclEQeE=
+github.com/docker/docker v0.7.3-0.20181229214054-f76d6a078d88 h1:kPa1mfIM7SSPWDbfmDo+IXTVwo3RNJbzrIZbreqi/BQ=
 github.com/docker/docker v0.7.3-0.20181229214054-f76d6a078d88/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v1.13.1 h1:5VBhsO6ckUxB0A8CE5LlUJdXzik9cbEbBTQ/ggeml7M=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
@@ -137,7 +137,7 @@ k8s.io/cli-runtime v0.0.0-20181004125037-79bf4e0b6454 h1:TMelxN+TDGOhDazOaU8M4s8
 k8s.io/cli-runtime v0.0.0-20181004125037-79bf4e0b6454/go.mod h1:qWnH3/b8sp/l7EvlDh7ulDU3UWA4P4N1NFbEEP791tM=
 k8s.io/cli-runtime v0.0.0-20181221202950-8abb1aeb8307 h1:x8ssI66Rojl2Q5vd9CvgZkwJBWiauDioKu8F3V9nBas=
 k8s.io/cli-runtime v0.0.0-20181221202950-8abb1aeb8307/go.mod h1:qWnH3/b8sp/l7EvlDh7ulDU3UWA4P4N1NFbEEP791tM=
-k8s.io/client-go v9.0.0+incompatible h1:NXWpDuPFeVB5lYP1fTqJUtwigjtmRXJNtndnN53ldGI=
+k8s.io/client-go v9.0.0+incompatible h1:2kqW3X2xQ9SbFvWZjGEHBLlWc1LG9JIJNXWkuqwdZ3A=
 k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/client-go v10.0.0+incompatible h1:+xQQxwjrcIPWDMJBAS+1G2FNk1McoPnb53xkvcDiDqE=
 k8s.io/client-go v10.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
@@ -145,7 +145,7 @@ k8s.io/klog v0.1.0 h1:I5HMfc/DtuVaGR1KPwUrTc476K8NCqNBldC7H4dYEzk=
 k8s.io/klog v0.1.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/kube-openapi v0.0.0-20181114233023-0317810137be h1:aWEq4nbj7HRJ0mtKYjNSk/7X28Tl6TI6FeG8gKF+r7Q=
 k8s.io/kube-openapi v0.0.0-20181114233023-0317810137be/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
-k8s.io/kubernetes v1.12.0 h1:jPDApxpqyQ/THiLnquNHidiHC1F8jvDi7BUGfNtue30=
+k8s.io/kubernetes v1.12.0 h1:2PjG+1oSb9SSwFkJIH6HZH85CDfJ7hOaMMMQYi1Q+0c=
 k8s.io/kubernetes v1.12.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/kubernetes v1.13.1 h1:d+D9yU/BwrI28BUGJtRhIcUqjlSjM5icZ1QITmdJHRE=
 k8s.io/kubernetes v1.13.1/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=


### PR DESCRIPTION
Hello,

The way Go modules construct hashes for dependencies has been changed in Go 1.11.4 ([a related issue here](https://github.com/golang/go/issues/29278)) and this causes hash mismatches when the `kcfishgen` module is built with a Go version of greater than 1.11.4, like the following

```
verifying k8s.io/kubernetes@v1.12.0: checksum mismatch
        downloaded: h1:2PjG+1oSb9SSwFkJIH6HZH85CDfJ7hOaMMMQYi1Q+0c=
        go.sum:     h1:jPDApxpqyQ/THiLnquNHidiHC1F8jvDi7BUGfNtue30=
```

This patch updates hashes of three dependencies to make the main module buildable with Go >= 1.11.4.

There is one caveat though; applying this patch may require the folks who have previously compiled with a Go version of less than 1.11.4 to perform a `go clean -modcache` to force a recalculation of the hashes for the dependencies which were affected by the mismatches.

Thanks.