### PR TITLE
Check for CRDs before listing them

### DIFF
--- a/completions/kubectl.fish
+++ b/completions/kubectl.fish
@@ -150,6 +150,9 @@ set __fish_kubectl_cached_crds ""
 set __fish_kubectl_last_crd_fetch ""
 
 function __fish_kubectl_actually_get_crds
+  if test (kubectl get crd --no-headers=true 2>/dev/null | wc -l) -eq 0
+    return
+  end
   set __fish_kubectl_cached_crds (__fish_kubectl get crd -o jsonpath='{range .items[*]}{.spec.names.plural}{"\n"}{.spec.names.singular}{"\n"}{range .spec.names.shortNames[]}{@}{"\n"}{end}{end}')
   set __fish_kubectl_last_crd_fetch (__fish_kubectl_get_current_time)
 	for i in $__fish_kubectl_cached_crds

--- a/main.go
+++ b/main.go
@@ -81,6 +81,9 @@ set __fish_kubectl_cached_crds ""
 set __fish_kubectl_last_crd_fetch ""
 
 function __fish_kubectl_actually_get_crds
+  if test (kubectl get crd --no-headers=true 2>/dev/null | wc -l) -eq 0
+    return
+  end
   set __fish_kubectl_cached_crds (__fish_kubectl get crd -o jsonpath='{range .items[*]}{.spec.names.plural}{"\n"}{.spec.names.singular}{"\n"}{range .spec.names.shortNames[]}{@}{"\n"}{end}{end}')
   set __fish_kubectl_last_crd_fetch (__fish_kubectl_get_current_time)
 	for i in $__fish_kubectl_cached_crds


### PR DESCRIPTION
Sub-resource completion seems to error with the following output when there are no CRDs defined:

```
error: error executing jsonpath "{range .items[*]}{.spec.names.plural}{\"\\n\"}{.spec.names.singular}{\"\\n\"}{range .spec.names.shortNames[]}{@}{\"\\n\"}{end}{end}": Error executing template: not in range, nothing to end. Printing more information for debugging the template:
        template was:
                {range .items[*]}{.spec.names.plural}{"\n"}{.spec.names.singular}{"\n"}{range .spec.names.shortNames[]}{@}{"\n"}{end}{end}
        object given to jsonpath engine was:
                map[string]interface {}{"apiVersion":"v1", "items":[]interface {}{}, "kind":"List", "metadata":map[string]interface {}{"resourceVersion":"", "selfLink":""}}
```

This patch checks if there are CRDs defined and if not, returns early from `__fish_kubectl_actually_get_crds`