### PR TITLE
use wrapper for getting CRDs

### DIFF
--- a/completions/kubectl.fish
+++ b/completions/kubectl.fish
@@ -150,7 +150,7 @@ set __fish_kubectl_cached_crds ""
 set __fish_kubectl_last_crd_fetch ""
 
 function __fish_kubectl_actually_get_crds
-  if test (kubectl get crd --no-headers=true 2>/dev/null | wc -l) -eq 0
+  if test (__fish_kubectl get crd --no-headers=true 2>/dev/null | wc -l) -eq 0
     return
   end
   set __fish_kubectl_cached_crds (__fish_kubectl get crd -o jsonpath='{range .items[*]}{.spec.names.plural}{"\n"}{.spec.names.singular}{"\n"}{range .spec.names.shortNames[]}{@}{"\n"}{end}{end}')
@@ -367,7 +367,7 @@ function __fish_kubectl_print_resource -d 'Print a list of resources' -a resourc
   end
 
   set args $args get "$resource"
-  __fish_kubectl $args --no-headers | awk '{print $1}' | string replace -r '(.*)/' ''
+  __fish_kubectl $args --no-headers 2>/dev/null | awk '{print $1}' | string replace -r '(.*)/' ''
 end
 
 function __fish_kubectl_get_config -a type

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ set __fish_kubectl_cached_crds ""
 set __fish_kubectl_last_crd_fetch ""
 
 function __fish_kubectl_actually_get_crds
-  if test (kubectl get crd --no-headers=true 2>/dev/null | wc -l) -eq 0
+  if test (__fish_kubectl get crd --no-headers=true 2>/dev/null | wc -l) -eq 0
     return
   end
   set __fish_kubectl_cached_crds (__fish_kubectl get crd -o jsonpath='{range .items[*]}{.spec.names.plural}{"\n"}{.spec.names.singular}{"\n"}{range .spec.names.shortNames[]}{@}{"\n"}{end}{end}')
@@ -298,7 +298,7 @@ function __fish_kubectl_print_resource -d 'Print a list of resources' -a resourc
   end
 
   set args $args get "$resource"
-  __fish_kubectl $args --no-headers | awk '{print $1}' | string replace -r '(.*)/' ''
+  __fish_kubectl $args --no-headers 2>/dev/null | awk '{print $1}' | string replace -r '(.*)/' ''
 end
 
 function __fish_kubectl_get_config -a type


### PR DESCRIPTION
This is actually one fix and addressing one edge case.

Fix: Use the wrapper function when invoking `kubectl` so that context is taken into account
Edge case: When there are no resources of given type, the completion prints `No resources found in default namespace.` to stderr, so redirect that listing to /dev/null.